### PR TITLE
feat: conditionally run `rdme` version depending on project status

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -16,13 +16,13 @@ jobs:
         id: refactored
         run: |
           refactored=$(curl https://api.readme.com/v2/projects/me --header 'Authorization: Bearer ${{ secrets.README_API_KEY }}' | jq -c '.data.refactored')
-          echo migrated=$(echo $refactored | jq -r '.migrated') >> $GITHUB_OUTPUT
-          echo status=$(echo $refactored | jq -r '.status') >> $GITHUB_OUTPUT
-
-      - name: Print Refactored data
-        run: |
-          echo ${{ steps.refactored.outputs.migrated }}
-          echo ${{ steps.refactored.outputs.status }}
+          migrated=$(echo $refactored | jq -r '.migrated')
+          status=$(echo $refactored | jq -r '.status')
+          echo "Refactored data: $refactored"
+          echo "Migrated: $migrated"
+          echo "Status: $status"
+          echo migrated=$migrated >> $GITHUB_OUTPUT
+          echo status=$status >> $GITHUB_OUTPUT
 
       # If project is not yet migrated, run legacy v9 action
       - name: GitHub Action

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -10,29 +10,38 @@ jobs:
       - name: Checkout this repo
         uses: actions/checkout@v4
 
-      - name: Grab Refactored status
-        id: refactored_status
+      # Fetches the refactored data from the ReadMe API's "Get project metadata" endpoint
+      # https://docs.readme.com/main/reference/getproject-1
+      - name: Grab Refactored data
+        id: refactored
         run: |
-          status=$(curl https://api.readme.com/v2/projects/me --header 'Authorization: Bearer ${{ secrets.README_API_KEY }}' | jq -r '.data.refactored.status')
-          echo result=$status >> $GITHUB_OUTPUT
+          refactored=$(curl https://api.readme.com/v2/projects/me --header 'Authorization: Bearer ${{ secrets.README_API_KEY }}') | jq -c '.data.refactored')
+          echo migrated=$(echo $refactored | jq -r '.migrated') >> $GITHUB_OUTPUT
+          echo status=$(echo $refactored | jq -r '.status') >> $GITHUB_OUTPUT
 
-      - name: Print Refactored status
-        run: echo ${{ steps.refactored_status.outputs.result }}
+      - name: Print Refactored data
+        run: |
+          echo ${{ steps.refactored.outputs.migrated }}
+          echo ${{ steps.refactored.outputs.status }}
 
-      # Run GitHub Action to sync OpenAPI file at [path-to-file.json]
+      # If project is not yet migrated, run legacy v9 action
       - name: GitHub Action
         # We recommend specifying a fixed version, i.e. @v8
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
-        if: ${{ steps.refactored_status.outputs.result == 'disabled' }}
+        if: ${{ steps.refactored.outputs.status == 'disabled' }}
         uses: readmeio/rdme@v9
         with:
           rdme: openapi petstore.json --key=${{ secrets.README_API_KEY }} --id=${{ secrets.README_API_DEFINITION_ID }}
 
-      # Run GitHub Action to sync OpenAPI file at [path-to-file.json]
+      # If project is successfully migrated, run v10 action
       - name: GitHub Action
-        # We recommend specifying a fixed version, i.e. @v8
-        # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
-        if: ${{ steps.refactored_status.outputs.result == 'enabled' }}
+        if: ${{ steps.refactored.outputs.migrated == 'successful' && steps.refactored.outputs.status == 'enabled' }}
         uses: readmeio/rdme@v10
         with:
           rdme: openapi upload petstore.json --key=${{ secrets.README_API_KEY }}
+
+      # If project is in an unexpected migration state, skip the rdme workflow
+      - name: GitHub Action
+        if: ${{ steps.refactored.outputs.migrated != 'successful' && steps.refactored.outputs.status == 'enabled' }}
+        run: |
+          echo "Project is in an unexpected migration state (${{ steps.refactored.outputs.migrated }}). Skipping `rdme` workflow."

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,10 +13,29 @@ jobs:
       - name: Checkout this repo
         uses: actions/checkout@v4
 
+      - name: Grab Refactored status
+        id: refactored_status
+        run: |
+          status=$(curl https://api.readme.com/v2/projects/me --header 'Authorization: Bearer ${{ secrets.README_API_KEY }}' | jq -r '.data.refactored.status')
+          echo result=$status >> $GITHUB_OUTPUT
+
+      - name: Print Refactored status
+        run: echo ${{ steps.refactored_status.outputs.result }}
+
       # Run GitHub Action to sync OpenAPI file at [path-to-file.json]
       - name: GitHub Action
         # We recommend specifying a fixed version, i.e. @v8
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
+        if: ${{ steps.refactored_status.outputs.result == 'disabled' }}
         uses: readmeio/rdme@v9
         with:
           rdme: openapi petstore.json --key=${{ secrets.README_API_KEY }} --id=${{ secrets.README_API_DEFINITION_ID }}
+
+      # Run GitHub Action to sync OpenAPI file at [path-to-file.json]
+      - name: GitHub Action
+        # We recommend specifying a fixed version, i.e. @v8
+        # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
+        if: ${{ steps.refactored_status.outputs.result == 'enabled' }}
+        uses: readmeio/rdme@v10
+        with:
+          rdme: openapi upload petstore.json --key=${{ secrets.README_API_KEY }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Grab Refactored data
         id: refactored
         run: |
-          refactored=$(curl https://api.readme.com/v2/projects/me --header 'Authorization: Bearer ${{ secrets.README_API_KEY }}') | jq -c '.data.refactored')
+          refactored=$(curl https://api.readme.com/v2/projects/me --header 'Authorization: Bearer ${{ secrets.README_API_KEY }}' | jq -c '.data.refactored')
           echo migrated=$(echo $refactored | jq -r '.migrated') >> $GITHUB_OUTPUT
           echo status=$(echo $refactored | jq -r '.status') >> $GITHUB_OUTPUT
 

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -41,7 +41,7 @@ jobs:
         if: ${{ steps.refactored.outputs.migrated == 'successful' && steps.refactored.outputs.status == 'enabled' }}
         uses: readmeio/rdme@v10
         with:
-          rdme: openapi upload petstore.json --key=${{ secrets.README_API_KEY }}
+          rdme: openapi upload petstore.json --key=${{ secrets.README_API_KEY }} --legacy-id=${{ secrets.README_API_DEFINITION_ID }}
 
       # If project is in an unexpected migration state, skip the rdme workflow
       - name: Skip due to unexpected migration state

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Skip due to unexpected migration state
         if: ${{ steps.refactored.outputs.migrated != 'successful' && steps.refactored.outputs.status == 'enabled' }}
         run: |
-          echo "Project is in an unexpected migration state (${{ steps.refactored.outputs.migrated }}). Skipping `rdme` workflow."
+          echo "::warning::Project is in an unexpected migration state (${{ steps.refactored.outputs.migrated }}). Skipping `rdme` workflow. Please contact us (support@readme.io) if you keep running into this issue."

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,10 +1,7 @@
 name: Sync OpenAPI definition to ReadMe
 
 # Run workflow for every push to the `main` branch
-on:
-  push:
-    branches:
-      - main
+on: push
 
 jobs:
   sync:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -25,7 +25,7 @@ jobs:
           echo status=$status >> $GITHUB_OUTPUT
 
       # If project is not yet migrated, run legacy v9 action
-      - name: GitHub Action
+      - name: Run rdme@9
         # We recommend specifying a fixed version, i.e. @v8
         # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
         if: ${{ steps.refactored.outputs.status == 'disabled' }}
@@ -34,14 +34,14 @@ jobs:
           rdme: openapi petstore.json --key=${{ secrets.README_API_KEY }} --id=${{ secrets.README_API_DEFINITION_ID }}
 
       # If project is successfully migrated, run v10 action
-      - name: GitHub Action
+      - name: Run rdme@10
         if: ${{ steps.refactored.outputs.migrated == 'successful' && steps.refactored.outputs.status == 'enabled' }}
         uses: readmeio/rdme@v10
         with:
           rdme: openapi upload petstore.json --key=${{ secrets.README_API_KEY }}
 
       # If project is in an unexpected migration state, skip the rdme workflow
-      - name: GitHub Action
+      - name: Skip due to unexpected migration state
         if: ${{ steps.refactored.outputs.migrated != 'successful' && steps.refactored.outputs.status == 'enabled' }}
         run: |
           echo "Project is in an unexpected migration state (${{ steps.refactored.outputs.migrated }}). Skipping `rdme` workflow."

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,7 +1,10 @@
 name: Sync OpenAPI definition to ReadMe
 
 # Run workflow for every push to the `main` branch
-on: push
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   sync:


### PR DESCRIPTION
## 🧰 Changes

adds an example workflow where we first check if the project is migrated and then conditionally run a version of `rdme` depending on the result. this should aid customers that want to have an `rdme` workflow in place for before/during/after migration to refactored.

## 🧬 QA & Testing

ran a few dry-runs and it seems solid. what do you think?
